### PR TITLE
Issue #3: Always highlight usernames and differentiate between mentions

### DIFF
--- a/chatclient.go
+++ b/chatclient.go
@@ -273,10 +273,9 @@ func (cl *Client) replaceColorizedName(chatData common.ChatData) common.ChatData
 	newWords := []string{}
 
 	nameSet := make(map[string]bool) // use map as a set
-	if chat == nil {
-		nameSet[strings.ToLower(cl.name)] = true
-		nameSet[strings.ToLower("@"+cl.name)] = true
-	} else {
+	nameSet[strings.ToLower(cl.name)] = true
+	nameSet[strings.ToLower("@"+cl.name)] = true
+	if chat != nil {
 		names := chat.GetNames() // locks
 		for _, name := range names {
 			nameSet[strings.ToLower(name)] = true
@@ -285,7 +284,12 @@ func (cl *Client) replaceColorizedName(chatData common.ChatData) common.ChatData
 	}
 	for _, word := range words {
 		if _, ok := nameSet[strings.ToLower(word)]; ok {
-			newWords = append(newWords, `<span class="mention">`+word+`</span>`)
+			// mention is for the current user
+			if strings.ToLower(word) == strings.ToLower(cl.name) || strings.ToLower(word) == strings.ToLower("@"+cl.name) {
+				newWords = append(newWords, `<span class="mention">`+word+`</span>`)
+			} else { // mention is for another user
+				newWords = append(newWords, `<span class="othermention">`+word+`</span>`)
+			}
 		} else {
 			newWords = append(newWords, word)
 		}

--- a/chatclient.go
+++ b/chatclient.go
@@ -272,8 +272,19 @@ func (cl *Client) replaceColorizedName(chatData common.ChatData) common.ChatData
 	words := strings.Split(data.Message, " ")
 	newWords := []string{}
 
+	nameSet := make(map[string]bool) // use map as a set
+	if chat == nil {
+		nameSet[strings.ToLower(cl.name)] = true
+		nameSet[strings.ToLower("@"+cl.name)] = true
+	} else {
+		names := chat.GetNames() // locks
+		for _, name := range names {
+			nameSet[strings.ToLower(name)] = true
+			nameSet[strings.ToLower("@"+name)] = true
+		}
+	}
 	for _, word := range words {
-		if strings.ToLower(word) == strings.ToLower(cl.name) || strings.ToLower(word) == strings.ToLower("@"+cl.name) {
+		if _, ok := nameSet[strings.ToLower(word)]; ok {
 			newWords = append(newWords, `<span class="mention">`+word+`</span>`)
 		} else {
 			newWords = append(newWords, word)

--- a/chatclient_test.go
+++ b/chatclient_test.go
@@ -52,4 +52,25 @@ func TestClient_emoteHighlight(t *testing.T) {
 			t.Logf("Passed %s", d[0])
 		}
 	}
+
+	// test highlighting with multiple users
+	// we expect all usernames to highlight for all users
+	chat = &ChatRoom{
+		queue:    make(chan common.ChatData, 1),
+		modqueue: make(chan common.ChatData, 1),
+		clients:  []*Client{},
+	}
+	chat.clients = append(chat.clients, client)
+	client2, err := NewClient(nil, chat, "Irani", "#9547ff")
+	if err != nil {
+		t.Errorf("Client init error: %v", err)
+	}
+	for _, d := range data {
+		chatData := client2.replaceColorizedName(common.NewChatMessage(client.name, client.color, d[0], common.CmdlUser, common.MsgChat))
+		if chatData.Data.(common.DataMessage).Message != d[1] {
+			t.Errorf("\nExpected:\n\t%s\nReceived\n\t%s", d[1], chatData.Data.(common.DataMessage).Message)
+		} else {
+			t.Logf("Passed %s", d[0])
+		}
+	}
 }

--- a/chatclient_test.go
+++ b/chatclient_test.go
@@ -65,6 +65,18 @@ func TestClient_emoteHighlight(t *testing.T) {
 	if err != nil {
 		t.Errorf("Client init error: %v", err)
 	}
+	data = [][]string{
+		{"zorchenhimer", `<span class="othermention">zorchenhimer</span>`},
+		{"@zorchenhimer", `<span class="othermention">@zorchenhimer</span>`},
+		{"Zorchenhimer", `<span class="othermention">Zorchenhimer</span>`},
+		{"@Zorchenhimer", `<span class="othermention">@Zorchenhimer</span>`},
+		{"hello zorchenhimer", `hello <span class="othermention">zorchenhimer</span>`},
+		{"hello zorchenhimer ass", `hello <span class="othermention">zorchenhimer</span> ass`},
+		{"irani", `<span class="mention">irani</span>`},
+		{"@irani", `<span class="mention">@irani</span>`},
+		{`<img src="/emotes/twitch/zorchenhimer/zorcheWhat.png" height="28px" title="zorcheWhat">`, `<img src="/emotes/twitch/zorchenhimer/zorcheWhat.png" height="28px" title="zorcheWhat">`},
+		{`zorchenhimer <img src="/emotes/twitch/zorchenhimer/zorcheWhat.png" height="28px" title="zorcheWhat">`, `<span class="othermention">zorchenhimer</span> <img src="/emotes/twitch/zorchenhimer/zorcheWhat.png" height="28px" title="zorcheWhat">`},
+	}
 	for _, d := range data {
 		chatData := client2.replaceColorizedName(common.NewChatMessage(client.name, client.color, d[0], common.CmdlUser, common.MsgChat))
 		if chatData.Data.(common.DataMessage).Message != d[1] {

--- a/static/css/site.css
+++ b/static/css/site.css
@@ -142,6 +142,13 @@ input[type=text] {
     text-align: center;
 }
 
+.othermention {
+    background:  #f61cc0d9 ;
+    color: var(--var-background-color);
+    padding: 1px 2px;
+    border-radius: 4px;
+}
+
 .mention {
     background: #1cf67ed9;
     color: var(--var-background-color);


### PR DESCRIPTION
change to always highlight usernames. ~does not include the color change, will do that in another.~ added the color change as well-- if the mention is for you v. another user, the colors will be different. for some reason the new `othermention` tag isn't working in incognito mode even though the tag is set properly. 

to get the list of valid usernames requires taking out a lock, which isn't ideal since it'll take out the lock for every chat being times the number of users (plus same lock is used for leaving/joining a chat), but since we don't have that many users it's probably fine.