### PR TITLE
Allow duplicate messages and remove limiting

### DIFF
--- a/settings.go
+++ b/settings.go
@@ -100,9 +100,7 @@ func LoadSettings(filename string) (*Settings, error) {
 		}
 	}
 
-	if s.RateLimitChat == -1 {
-		s.RateLimitChat = 0
-	} else if s.RateLimitChat <= 0 {
+	if s.RateLimitChat < 0 {
 		s.RateLimitChat = 1
 	}
 
@@ -124,9 +122,7 @@ func LoadSettings(filename string) (*Settings, error) {
 		s.RateLimitAuth = 5
 	}
 
-	if s.RateLimitDuplicate == -1 {
-		s.RateLimitDuplicate = 0
-	} else if s.RateLimitDuplicate <= 0 {
+	if s.RateLimitDuplicate < 0 {
 		s.RateLimitDuplicate = 30
 	}
 

--- a/settings_example.json
+++ b/settings_example.json
@@ -9,11 +9,11 @@
 	"ApprovedEmotes": null,
 	"LogLevel": "debug",
 	"LogFile": "thelog.log",
-	"RateLimitChat": 1,
+	"RateLimitChat": 0,
 	"RateLimitNick": 300,
 	"RateLimitColor": 60,
 	"RateLimitAuth": 5,
-	"RateLimitDuplicate": 30,
+	"RateLimitDuplicate": 0,
 	"NoCache": false,
 	"WrappedEmotesOnly": true
 }


### PR DESCRIPTION
looks like the `settings.json` file is generated at build time based off of the `settings_example.json` file. i updated the values there to 0, and changed the code to not override values of 0 in the settings-- this was just an annoying thing for local development because when the -1 settings value was overridden to 0, the next time you build the 0 is overridden to 30 unless you delete the settings.json file. not required for prod usage tho and can undo that.

#12 